### PR TITLE
Fix to call JumbleQuery() in the sql_firewall module.

### DIFF
--- a/README
+++ b/README
@@ -15,10 +15,15 @@ to work with the sql_firewall extension at the same time.
     resolve the name conflict even if you already have
     pg_stat_statements.
 
- 2. Query Id is calculated using relation names instead of relation
-    ids which is done by the original pg_stat_statements. So, Query Id
-    can keep the same value even if the table get re-created (drop &
-    create).
+ 2. JumbleQuery() function is removed from this module, and
+    pgss_post_parse_analyze() calls JumbleQuery() in the sql_firewall
+    module (shared library).
+
+    So, this module must be used with the sql_firewall module, and it
+    needs to be loaded prior to the pg_stat_statements2 as following:
+
+      shared_preload_libraries = 'sql_firewall,pg_stat_statements2'
+
 
 Authors
 -------

--- a/pg_stat_statements2.c
+++ b/pg_stat_statements2.c
@@ -217,6 +217,8 @@ typedef struct pgssJumbleState
 	int			clocations_count;
 } pgssJumbleState;
 
+extern void JumbleQuery(pgssJumbleState *jstate, Query *query);
+
 /*---- Local variables ----*/
 
 /* Current nesting depth of ExecutorRun+ProcessUtility calls */
@@ -313,12 +315,13 @@ static char *qtext_fetch(Size query_offset, int query_len,
 static bool need_gc_qtexts(void);
 static void gc_qtexts(void);
 static void entry_reset(void);
+#ifdef NOT_USED
 static void AppendJumble(pgssJumbleState *jstate,
 			 const unsigned char *item, Size size);
-static void JumbleQuery(pgssJumbleState *jstate, Query *query);
 static void JumbleRangeTable(pgssJumbleState *jstate, List *rtable);
 static void JumbleExpr(pgssJumbleState *jstate, Node *node);
 static void RecordConstLocation(pgssJumbleState *jstate, int location);
+#endif /* NOT_USED */
 static char *generate_normalized_query(pgssJumbleState *jstate, const char *query,
 						  int *query_len_p, int encoding);
 static void fill_in_constant_lengths(pgssJumbleState *jstate, const char *query);
@@ -2136,6 +2139,7 @@ done:
 	LWLockRelease(pgss->lock);
 }
 
+#ifdef NOT_USED
 /*
  * AppendJumble: Append a value that is substantive in a given query to
  * the current jumble.
@@ -2693,6 +2697,8 @@ RecordConstLocation(pgssJumbleState *jstate, int location)
 		jstate->clocations_count++;
 	}
 }
+
+#endif /* NOT_USED */
 
 /*
  * Generate a normalized version of the query string that will be used to


### PR DESCRIPTION
In order to have the same queryid value in both sql_firewall and
pg_stat_statements2, duplicated JumbleQuery() in pg_stat_statements2
should be removed.

Since the pg_stat_statements2 module calls JumbleQuery() in the
sql_firewall shared library, the sql_firewall module needs to be
loaded prior to the pg_stat_statements2 as following:

  shared_preload_libraries = 'sql_firewall,pg_stat_statements2'
